### PR TITLE
Implement credential check on MetricsScreen with useFocusEffect

### DIFF
--- a/screens/MetricsScreen/MetricsScreen.js
+++ b/screens/MetricsScreen/MetricsScreen.js
@@ -1,5 +1,7 @@
-import React from "react";
-import { StatusBar } from "react-native";
+import React, { useState, useEffect } from "react";
+import { StatusBar, Text } from "react-native";
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import { useFocusEffect } from "@react-navigation/native";
 import {
   StyledContainer,
   InnerContainer,
@@ -8,6 +10,34 @@ import {
 } from "./MetricsScreenStyles";
 
 const MetricsScreen = () => {
+  const [storedCredentials, setStoredCredentials] = useState(null);
+
+  // Function to load stored credentials
+  const loadCredentials = async () => {
+    try {
+      const credentials = await AsyncStorage.getItem("zenTimerCredentials");
+      if (credentials !== null) {
+        setStoredCredentials(JSON.parse(credentials));
+      } else {
+        setStoredCredentials(null);
+      }
+    } catch (error) {
+      console.log("Error loading credentials", error);
+    }
+  };
+
+  // Load credentials on screen focus
+  useFocusEffect(
+    React.useCallback(() => {
+      loadCredentials();
+    }, [])
+  );
+
+  // Initial load on component mount
+  useEffect(() => {
+    loadCredentials();
+  }, []);
+
   return (
     <StyledContainer testID="metrics-container">
       <StatusBar style="light" />
@@ -15,9 +45,19 @@ const MetricsScreen = () => {
         <PageTitle welcome={true} testID="metrics-title">
           Metrics Page
         </PageTitle>
-        <SubTitle welcome={true} testID="page-development">
-          This page is currently under development.
-        </SubTitle>
+        {storedCredentials ? (
+          <>
+            <SubTitle welcome={true} testID="user-greeting">
+              Welcome back, {storedCredentials.name}!
+            </SubTitle>
+            <Text>Email: {storedCredentials.email}</Text>
+            {/* You can show more data from credentials if available */}
+          </>
+        ) : (
+          <SubTitle welcome={true} testID="page-development">
+            No credentials found. Please log in.
+          </SubTitle>
+        )}
       </InnerContainer>
     </StyledContainer>
   );


### PR DESCRIPTION

This pull request introduces the following changes to the `MetricsScreen` component:

Credential Check on Focus**: Utilized `useFocusEffect` from `@react-navigation/native` to check for stored credentials every time the screen is focused. This ensures that users see the most current information without needing to refresh the app.

Dynamic User Greeting**: If credentials are found, the screen now displays a personalized greeting with the user's name and email address.

User Prompt: If no credentials are found, the screen informs the user to log in.
