### PR TITLE
Fix: Ensure stopwatch pauses correctly during save operation

### DIFF
--- a/screens/StopwatchScreen/StopwatchScreen.js
+++ b/screens/StopwatchScreen/StopwatchScreen.js
@@ -233,6 +233,7 @@ const StopwatchScreen = () => {
   const debouncedSaveTimeRecords = debounce(
     () => {
       if (!buttonsDisabled) {
+        pauseStopwatch();
         saveTimeRecords();
         handleButtonPress(9);
       }


### PR DESCRIPTION
This PR addresses a bug where the timer state could break if the user attempted to save without valid credentials, and subsequently resumed the timer. The issue stemmed from inconsistent handling of the isRunning state during save attempts.