### PR TITLE
Fix StyleButtonWidth Issue in Web Version

### DIFF
--- a/screens/MetricsScreen/MetricsScreenStyles.js
+++ b/screens/MetricsScreen/MetricsScreenStyles.js
@@ -20,7 +20,7 @@ const {
 
 const containerHeight = Platform.OS === "web" ? "85%" : "90%";
 const containerWidth = Platform.OS === "web" ? "100%" : "100%";
-const StyledButtonWidth = Platform.OS === "web" ? "30%" : "90%";
+const StyledButtonWidth = Platform.OS === "web" ? "250px" : "90%";
 
 export const StyledContainer = styled(SafeAreaView)`
   flex: 1;


### PR DESCRIPTION
This pull request addresses a minor but important issue with StyleButtonWidth in the web version. The button width was previously defined as a percentage, causing layout inconsistencies. We've updated it to use a static size in px, ensuring proper rendering across all screen sizes.